### PR TITLE
Feature/table row support composite keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.3.0]
 
 Better support for using composite primary keys:
 
 * New enum in this crate: `tables::PrimaryKey`
-    * Single(string): `let sng_pk: PrimaryKey = "hello world".into()`
-    * Composite(BTreeMap<String, String>: `let cmp_pk: PrimaryKey = [("evt_tx_hash","hello".to_string()),("evt_index","world".to_string())].into()`
+    * `Single(String)`: `let single: PrimaryKey = "hello world".into()`
+    * `Composite(BTreeMap<String, String>)`: `let composite: PrimaryKey = [("evt_tx_hash","hello".to_string()),("evt_index","world".to_string())].into()`
 
 Breaking changes:
 
-* The `Rows` struct now requires pks to be of that new `PrimaryKey` type.
-* create_row(), update_row() and delete_row() now require a `PrimaryKey` instead of a String.
+* The `Rows.pks` field is not public anymore.
+* `create_row()`, `update_row()` and `delete_row()` now require a `PrimaryKey` instead of a `String`. This should work directly with a `String`, `&String` or `&str`.
 
 ## [1.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Better support for using composite primary keys:
+
+* New enum in this crate: `tables::PrimaryKey`
+    * Single(string): `let sng_pk: PrimaryKey = "hello world".into()`
+    * Composite(BTreeMap<String, String>: `let cmp_pk: PrimaryKey = [("evt_tx_hash","hello".to_string()),("evt_index","world".to_string())].into()`
+
+Breaking changes:
+
+* The `Rows` struct now requires pks to be of that new `PrimaryKey` type.
+* create_row(), update_row() and delete_row() now require a `PrimaryKey` instead of a String.
+
 ## [1.2.1]
 
 * Changed imports in `substreams.yaml` definition so that packaged `.spkg` can you the expect path `sf/substreams/sink/database/v1` to exclude and generating from the `.spkg` will generate data on the right path.


### PR DESCRIPTION
example usage for composite primary key in BAYC substreams:

```
    events.approvals.into_iter().for_each(|evt| {
        tables
            .create_row("approval", [("evt_tx_hash", evt.evt_tx_hash),("evt_index", evt.evt_index.to_string())].into())
            .set("evt_block_time", evt.evt_block_time.unwrap())
            .set("evt_block_number", evt.evt_block_number)
            .set("approved", Hex(&evt.approved).to_string())
            .set("owner", Hex(&evt.owner).to_string())
            .set("token_id", BigDecimal::from_str(&evt.token_id).unwrap());
    });
```

note that we don't need the evt_tx_hash and evt_index fields to be repeated in the `set(...)` commands, as they are part of the primary key.

The primary could also simply be `format("{}-{}", evt.evt_tx_hash, evt.evt_index).into()` for a Single key.